### PR TITLE
Simplify adding multiple objects

### DIFF
--- a/Source/Model/MJGSortedMutableArray.h
+++ b/Source/Model/MJGSortedMutableArray.h
@@ -21,8 +21,7 @@
 - (id)initWithSelector:(SEL)selector;
 
 - (NSUInteger)addObject:(id)obj;
-- (NSArray*)addObjects:(NSArray*)objects;
-- (void)addObjects:(NSArray*)objects addedIndices:(NSUInteger*)indices;
+- (NSIndexSet*)addObjectsFromArray:(NSArray*)otherArray;
 - (void)removeObjectAtIndex:(NSUInteger)index;
 - (void)removeObjectsInRange:(NSRange)range;
 - (void)removeAllObjects;

--- a/Source/Model/MJGSortedMutableArray.m
+++ b/Source/Model/MJGSortedMutableArray.m
@@ -106,20 +106,20 @@
     return addedIndex;
 }
 
-- (NSArray*)addObjects:(NSArray*)objects {
-    NSUInteger *indices = malloc(sizeof(NSUInteger) * objects.count);
-    [self addObjects:objects addedIndices:indices];
+- (NSIndexSet*)addObjectsFromArray:(NSArray *)otherArray {
+    NSUInteger *indices = malloc(sizeof(NSUInteger) * otherArray.count);
+    [self addObjects:otherArray addedIndices:indices];
     
-    NSMutableArray *returnArray = [NSMutableArray new];
-    for (NSUInteger i = 0; i < objects.count; i++) {
-        [returnArray addObject:@(indices[i])];
+    NSMutableIndexSet *result = [NSMutableIndexSet indexSet];
+    for (NSUInteger i = 0; i < otherArray.count; i++) {
+        [result addIndex:indices[i]];
     }
     
     if (indices) {
         free(indices);
     }
     
-    return [returnArray copy];
+    return result;
 }
 
 - (void)addObjects:(NSArray*)objects addedIndices:(NSUInteger*)indices {

--- a/Tests/MJGSortedMutableArrayTests/Source/MJGSortedMutableArrayTests.m
+++ b/Tests/MJGSortedMutableArrayTests/Source/MJGSortedMutableArrayTests.m
@@ -100,14 +100,14 @@ NSComparisonResult compareNumbers(NSNumber *obj1, NSNumber *obj2, void *context)
                              [NSNumber numberWithInt:1],
                              [NSNumber numberWithInt:3],
                              nil];
-    NSArray *addedIndices = [_array addObjects:objectsToAdd];
+    NSIndexSet *addedIndices = [_array addObjectsFromArray:objectsToAdd];
     
-    STAssertEquals(addedIndices.count, (NSUInteger)5, @"Incorrect number of indices returned");
-    STAssertEquals([[addedIndices objectAtIndex:0] unsignedIntegerValue], (NSUInteger)0, @"Incorrect index returned");
-    STAssertEquals([[addedIndices objectAtIndex:1] unsignedIntegerValue], (NSUInteger)2, @"Incorrect index returned");
-    STAssertEquals([[addedIndices objectAtIndex:2] unsignedIntegerValue], (NSUInteger)4, @"Incorrect index returned");
-    STAssertEquals([[addedIndices objectAtIndex:3] unsignedIntegerValue], (NSUInteger)1, @"Incorrect index returned");
-    STAssertEquals([[addedIndices objectAtIndex:4] unsignedIntegerValue], (NSUInteger)3, @"Incorrect index returned");
+    STAssertTrue(addedIndices.count, @"Incorrect number of indices returned");
+    STAssertTrue([addedIndices containsIndex:0], @"Incorrect index returned");
+    STAssertTrue([addedIndices containsIndex:2], @"Incorrect index returned");
+    STAssertTrue([addedIndices containsIndex:4], @"Incorrect index returned");
+    STAssertTrue([addedIndices containsIndex:1], @"Incorrect index returned");
+    STAssertTrue([addedIndices containsIndex:3], @"Incorrect index returned");
 }
 
 @end


### PR DESCRIPTION
Replaces `-addObjects:` with `-addObjectsFromArray:` which returns an `NSIndexSet`.

I realise there is one downside to this method: as an index _set_, there's no inherent ordering. So you can't, say, look up "where was the second object from my array inserted?". I'm inclined to say such a question doesn't make sense in the real world; that if you needed to know that, you might as well iterate the array inserting one-by-one anyway.
