### PR TITLE
Add initial podspec

### DIFF
--- a/MJGFoundation.podspec
+++ b/MJGFoundation.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name         = "MJGFoundation"
+  s.version      = "1.0.0"
+  s.summary      = "A collection of iOS classes & categories by Matt Galloway."
+  s.homepage     = "https://github.com/mattjgalloway/MJGFoundation"
+  s.license      = "BSD"
+  s.author       = { "Matt Galloway" => "matt@galloway.me.uk" }
+  s.source       = { :git => "https://github.com/mattjgalloway/MJGFoundation.git", :tag => "1.0.0" }
+  s.platform     = :ios, "5.0"
+  s.source_files = "Source/**/*.{h,m}"
+  s.resources    = "Resources/**/*.png"
+  s.library      = "z"
+  s.requires_arc = true
+
+  s.subspec "MJGAvailability" do |sp|
+    sp.summary      = "Produces compiler warnings for APIs newer than your deployment target."
+    sp.source_files = "Source/Utilities/MJGAvailability.h"
+  end
+end


### PR DESCRIPTION
This is a basic [podspec](http://docs.cocoapods.org/specification.html) to add MJGFoundation as a [CocoaPods](http://cocoapods.org/) library. It also includes a [subspec](http://docs.cocoapods.org/specification.html#subspec), MJGFoundation/MJGAvailability, which users can source if they only need the availability compiler warnings. It could be useful to expand into other subspecs for MJGFoundation's various components.

If the pull request looks good and is accepted, the repo will need to be tagged with `1.0.0` and a pull request will then be sent to the [CocoaPods specs](https://github.com/CocoaPods/Specs).
